### PR TITLE
Add github builtin authorization to support private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,13 @@ runs:
         url="${GITHUB_API_URL}/repos"
         repo="${GITHUB_REPOSITORY}"
         run_id="${GITHUB_RUN_ID}"
+        token="${{ github.token }}"
 
-        failure=$(curl -s "${url}/${repo}/actions/runs/${run_id}/jobs" | \
+        failure=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs" | \
         jq -r '.jobs[] | select(.status == "completed" and .conclusion == "failure").conclusion' | \
         wc -l)
 
-        cancelled=$(curl -s "${url}/${repo}/actions/runs/${run_id}/jobs" | \
+        cancelled=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs" | \
         jq -r '.jobs[] | select(.status == "completed" and .conclusion == "cancelled").conclusion' | \
         wc -l)
 


### PR DESCRIPTION
Per my own testing and #5 it seems like this action currently only works for public repositories. I needed it in a private repository, and the fix is real simple.

Whenever Github Actions is enabled for a repository, a Github Apps is installed and the `${{ github.token }}` variable is exposed. 

The proposed changes piggybacks on the fact that variable will always be populated and thus we can lookup the workflow status for both private and public repositories.