### PR TITLE
set status to GITHUB_OUTPUT ahead of set-output deprecation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
           status="success"
         fi
 
-        echo "{status}=${status}" >> $GITHUB_OUTPUT
+        echo "status=${status}" >> $GITHUB_OUTPUT
       shell: bash
 branding:
   icon: check-square

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ runs:
         else 
           status="success"
         fi
-        
-        echo "::set-output name=status::${status}"
+
+        echo "{name}=${status}" >> $GITHUB_OUTPUT"
       shell: bash
 branding:
   icon: check-square

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
           status="success"
         fi
 
-        echo "{name}=${status}" >> $GITHUB_OUTPUT"
+        echo "{status}=${status}" >> $GITHUB_OUTPUT
       shell: bash
 branding:
   icon: check-square


### PR DESCRIPTION
Started observing this message in the builds lately:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The proposed fix is inline with the [reference](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

This is in preparation ahead of the `set-output` command deprecation @ 31st May 2023. 