### PR TITLE
Fetch max number of jobs when checking status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,11 @@ runs:
         run_id="${GITHUB_RUN_ID}"
         token="${{ github.token }}"
 
-        failure=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs" | \
+        failure=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs?per_page=100" | \
         jq -r '.jobs[] | select(.status == "completed" and .conclusion == "failure").conclusion' | \
         wc -l)
 
-        cancelled=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs" | \
+        cancelled=$(curl -s -H "Authorization: token ${token}" "${url}/${repo}/actions/runs/${run_id}/jobs?per_page=100" | \
         jq -r '.jobs[] | select(.status == "completed" and .conclusion == "cancelled").conclusion' | \
         wc -l)
 


### PR DESCRIPTION
Per https://docs.github.com/en/rest/actions/workflow-jobs?apiVersion=2022-11-28#list-jobs-for-a-workflow-run the default limit for number of fetched jobs is 30. This PR increases the limit to the max value possible (100) as I have workflows with more than 30 jobs. The long-term solution of-course would to properly implement pagination per https://docs.github.com/rest/using-the-rest-api/using-pagination-in-the-rest-api